### PR TITLE
Implement backend event processing and add TUI client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +45,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -178,6 +234,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "automatatui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "automatafl-logic",
+ "clap",
+ "crossterm",
+ "futures",
+ "ratatui",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +368,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0b03af37dad7a14518b7691d81acb0f8222604ad3d1b02f6b4bed5188c0cd5"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,8 +410,48 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "codee"
@@ -341,6 +469,25 @@ name = "collection_literals"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -425,6 +572,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +601,32 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -530,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +732,16 @@ name = "erased"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1731451909bde27714eacba19c2566362a7f35224f52b153d3f42cf60f72472"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "event-listener"
@@ -563,6 +765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +781,27 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -685,6 +914,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -777,6 +1017,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1046,17 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -884,6 +1154,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http 1.3.1",
  "http-body",
  "httparse",
@@ -893,6 +1164,39 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -901,14 +1205,24 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http 1.3.1",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1070,6 +1384,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,7 +1464,7 @@ dependencies = [
  "cfg-if",
  "either_of",
  "futures",
- "getrandom",
+ "getrandom 0.3.3",
  "hydration_context",
  "leptos_config",
  "leptos_dom",
@@ -1196,7 +1550,7 @@ dependencies = [
  "cfg-if",
  "convert_case 0.8.0",
  "html-escape",
- "itertools",
+ "itertools 0.14.0",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -1278,6 +1632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1658,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "manyhow"
@@ -1361,6 +1730,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -1368,6 +1749,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1464,6 +1862,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1995,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1709,7 +2163,27 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1749,7 +2223,7 @@ checksum = "79983e88dfd1a2925e29a4853ab9161b234ea78dd0d44ed33a706c9cd5e35762"
 dependencies = [
  "dashmap",
  "guardian",
- "itertools",
+ "itertools 0.14.0",
  "or_poisoned",
  "paste",
  "reactive_graph",
@@ -1810,6 +2284,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http 1.3.1",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstml"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +2374,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,10 +2441,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2068,6 +2674,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,10 +2738,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2144,6 +2821,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2154,6 +2834,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2171,7 +2872,7 @@ dependencies = [
  "futures",
  "html-escape",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "linear-map",
  "next_tuple",
@@ -2188,6 +2889,19 @@ dependencies = [
  "throw_error",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2268,7 +2982,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2290,6 +3004,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +3033,19 @@ dependencies = [
  "log",
  "tokio",
  "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2346,6 +3093,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2419,6 +3184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,10 +3245,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -2510,12 +3304,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -2526,6 +3326,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2550,6 +3356,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2687,6 +3502,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,6 +3527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,7 +3540,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -2737,12 +3574,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2751,7 +3605,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2782,6 +3645,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2803,7 +3690,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2813,6 +3700,12 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2828,6 +3721,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2837,6 +3736,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2864,6 +3769,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2873,6 +3784,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2888,6 +3805,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2897,6 +3820,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3007,6 +3936,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["logic", "webapp", "backend"]
+members = ["logic", "webapp", "backend", "automatatui"]
 
 [workspace.package]
 version = "0.1.0"

--- a/automatatui/Cargo.toml
+++ b/automatatui/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "automatatui"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1.0"
+automatafl-logic = { path = "../logic" }
+clap = { version = "4.5", features = ["derive"] }
+crossterm = { version = "0.27", features = ["event-stream"] }
+futures = "0.3"
+ratatui = "0.26"
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time"] }
+uuid = { version = "1.7", features = ["serde", "v4"] }

--- a/automatatui/src/api.rs
+++ b/automatatui/src/api.rs
@@ -1,0 +1,88 @@
+use automatafl_logic::{
+    Coord, Game, Move, MoveFeedback, MoveResult as LogicMoveResult, Pid, RoundState,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+pub struct GameSnapshot {
+    pub id: Uuid,
+    pub game: Game,
+    pub players: Vec<PlayerSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlayerSummary {
+    pub uuid: Uuid,
+    pub pid: Pid,
+    pub displayname: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum GameEvent {
+    PlayerJoined {
+        player: PlayerSummary,
+    },
+    MoveQueued {
+        pid: Pid,
+    },
+    MoveRejected {
+        pid: Pid,
+        feedback: MoveFeedback,
+    },
+    ConflictsDetected {
+        moves: Vec<Move>,
+    },
+    MovesResolved {
+        results: Vec<AppliedMove>,
+        automaton: Option<AutomatonMotion>,
+        winner: Option<Pid>,
+    },
+    RoundState {
+        round: RoundState,
+        locked: Vec<Pid>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AppliedMove {
+    pub mv: Move,
+    pub outcome: LogicMoveResult,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AutomatonMotion {
+    pub from: Coord,
+    pub to: Coord,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventEnvelope {
+    pub seq: u64,
+    pub event: GameEvent,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EventsResponse {
+    pub events: Vec<EventEnvelope>,
+    pub next_seq: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MoveAttemptResult {
+    pub feedback: MoveFeedback,
+    pub enqueued: bool,
+}
+
+#[derive(Serialize)]
+pub struct RegisterPlayerRequest<'a> {
+    pub displayname: &'a str,
+    pub password: &'a str,
+}
+
+#[derive(Serialize)]
+pub struct PerformMoveRequest {
+    pub from: Coord,
+    pub to: Coord,
+}

--- a/automatatui/src/main.rs
+++ b/automatatui/src/main.rs
@@ -1,0 +1,650 @@
+use std::io::{self, Write};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use automatafl_logic::{Coord, Game, Particle, Pid, RoundState};
+use clap::Parser;
+use crossterm::{
+    event::{Event as CrosstermEvent, EventStream, KeyCode, KeyEvent, KeyModifiers},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use futures::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+use tokio::time::interval;
+use uuid::Uuid;
+
+use api::{
+    AppliedMove, EventEnvelope, EventsResponse, GameEvent, GameSnapshot, MoveAttemptResult,
+    PlayerSummary,
+};
+
+mod api;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Play Automatafl from the terminal", long_about = None)]
+struct Cli {
+    #[arg(long, default_value = "http://127.0.0.1:3000")]
+    server: String,
+    #[arg(long)]
+    player: Option<Uuid>,
+    #[arg(long)]
+    player_name: Option<String>,
+    #[arg(long)]
+    player_password: Option<String>,
+    #[arg(long)]
+    game: Option<Uuid>,
+    #[arg(long)]
+    create_game: bool,
+    #[arg(long, default_value_t = 250)]
+    poll_ms: u64,
+}
+
+struct BackendClient {
+    base: String,
+    http: reqwest::Client,
+}
+
+impl BackendClient {
+    fn new(base: String) -> Result<Self> {
+        Ok(Self {
+            base,
+            http: reqwest::Client::new(),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        let mut base = self.base.trim_end_matches('/').to_string();
+        base.push('/');
+        base.push_str(path.trim_start_matches('/'));
+        base
+    }
+
+    async fn register_player(&self, displayname: &str, password: &str) -> Result<Uuid> {
+        let url = self.url("/api/v1/register");
+        let resp = self
+            .http
+            .post(url)
+            .json(&api::RegisterPlayerRequest {
+                displayname,
+                password,
+            })
+            .send()
+            .await?;
+        let uuid = resp.error_for_status()?.json::<Uuid>().await?;
+        Ok(uuid)
+    }
+
+    async fn create_game(&self) -> Result<Uuid> {
+        let url = self.url("/api/v1/games");
+        let resp = self.http.post(url).send().await?;
+        Ok(resp.error_for_status()?.json::<Uuid>().await?)
+    }
+
+    async fn join_game(&self, game: Uuid, player: Uuid) -> Result<Pid> {
+        let url = self.url(&format!("/api/v1/games/{}", game));
+        let resp = self
+            .http
+            .post(url)
+            .query(&[("player_uuid", player.to_string())])
+            .send()
+            .await?;
+        Ok(resp.error_for_status()?.json::<Pid>().await?)
+    }
+
+    async fn snapshot(&self, game: Uuid) -> Result<GameSnapshot> {
+        let url = self.url(&format!("/api/v1/games/{}", game));
+        let resp = self.http.get(url).send().await?;
+        Ok(resp.error_for_status()?.json::<GameSnapshot>().await?)
+    }
+
+    async fn fetch_events(
+        &self,
+        game: Uuid,
+        player: Option<Uuid>,
+        since: u64,
+    ) -> Result<EventsResponse> {
+        let url = self.url(&format!("/api/v1/games/{}/events", game));
+        let mut query: Vec<(String, String)> = Vec::new();
+        if let Some(player) = player {
+            query.push(("player_uuid".into(), player.to_string()));
+        }
+        if since > 0 {
+            query.push(("since".into(), since.to_string()));
+        }
+        let resp = self.http.get(url).query(&query).send().await?;
+        Ok(resp.error_for_status()?.json::<EventsResponse>().await?)
+    }
+
+    async fn perform_move(
+        &self,
+        game: Uuid,
+        player: Uuid,
+        from: Coord,
+        to: Coord,
+    ) -> Result<MoveAttemptResult> {
+        let url = self.url(&format!("/api/v1/games/{}/move", game));
+        let resp = self
+            .http
+            .post(url)
+            .query(&[("player_uuid", player.to_string())])
+            .json(&api::PerformMoveRequest { from, to })
+            .send()
+            .await?;
+        Ok(resp.error_for_status()?.json::<MoveAttemptResult>().await?)
+    }
+}
+
+struct App {
+    client: BackendClient,
+    game_id: Uuid,
+    player_uuid: Uuid,
+    pid: Pid,
+    game: Option<Game>,
+    players: Vec<PlayerSummary>,
+    cursor: Coord,
+    phase: SelectionPhase,
+    log: Vec<String>,
+    next_seq: u64,
+    needs_state_refresh: bool,
+    should_quit: bool,
+    locked_players: Vec<Pid>,
+    current_round: RoundState,
+}
+
+#[derive(Copy, Clone)]
+enum SelectionPhase {
+    SelectingSource,
+    SelectingDestination { from: Coord },
+}
+
+impl SelectionPhase {
+    fn selected(&self) -> Option<Coord> {
+        match self {
+            SelectionPhase::SelectingDestination { from } => Some(*from),
+            SelectionPhase::SelectingSource => None,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            SelectionPhase::SelectingSource => "Select source",
+            SelectionPhase::SelectingDestination { .. } => "Select destination",
+        }
+    }
+}
+
+impl App {
+    fn new(client: BackendClient, game_id: Uuid, player_uuid: Uuid, pid: Pid) -> Self {
+        Self {
+            client,
+            game_id,
+            player_uuid,
+            pid,
+            game: None,
+            players: Vec::new(),
+            cursor: Coord { x: 0, y: 0 },
+            phase: SelectionPhase::SelectingSource,
+            log: Vec::new(),
+            next_seq: 0,
+            needs_state_refresh: true,
+            should_quit: false,
+            locked_players: Vec::new(),
+            current_round: RoundState::Fresh,
+        }
+    }
+
+    fn push_log<S: Into<String>>(&mut self, msg: S) {
+        self.log.push(msg.into());
+        if self.log.len() > 200 {
+            let excess = self.log.len() - 200;
+            self.log.drain(0..excess);
+        }
+    }
+
+    fn player_label(&self) -> String {
+        if let Some(info) = self.players.iter().find(|p| p.uuid == self.player_uuid) {
+            format!("{} (P{})", info.displayname, info.pid.0)
+        } else {
+            format!("Player {}", self.pid.0)
+        }
+    }
+
+    fn name_for_pid(&self, pid: Pid) -> String {
+        self.players
+            .iter()
+            .find(|p| p.pid == pid)
+            .map(|p| p.displayname.clone())
+            .unwrap_or_else(|| format!("Player {}", pid.0))
+    }
+
+    fn selected_coord(&self) -> Option<Coord> {
+        self.phase.selected()
+    }
+
+    fn clamp_cursor(&mut self) {
+        if let Some(game) = &self.game {
+            let width = game.board.size.x.saturating_sub(1);
+            let height = game.board.size.y.saturating_sub(1);
+            self.cursor.x = self.cursor.x.min(width);
+            self.cursor.y = self.cursor.y.min(height);
+        }
+    }
+
+    async fn refresh_state(&mut self) -> Result<()> {
+        let snapshot = self.client.snapshot(self.game_id).await?;
+        debug_assert_eq!(snapshot.id, self.game_id);
+        self.current_round = snapshot.game.round;
+        self.locked_players = snapshot.game.locked_players.iter().copied().collect();
+        self.game = Some(snapshot.game);
+        self.players = snapshot.players;
+        self.clamp_cursor();
+        self.needs_state_refresh = false;
+        Ok(())
+    }
+
+    async fn poll(&mut self) -> Result<()> {
+        if self.should_quit {
+            return Ok(());
+        }
+        let EventsResponse { events, next_seq } = self
+            .client
+            .fetch_events(self.game_id, Some(self.player_uuid), self.next_seq)
+            .await?;
+        self.next_seq = next_seq;
+        for EventEnvelope { seq, event } in events {
+            let _ = seq;
+            self.handle_event(event);
+        }
+        if self.needs_state_refresh {
+            self.refresh_state().await?;
+        }
+        Ok(())
+    }
+
+    fn handle_event(&mut self, event: GameEvent) {
+        match event {
+            GameEvent::PlayerJoined { player } => {
+                self.players.retain(|p| p.uuid != player.uuid);
+                self.players.push(player.clone());
+                self.push_log(format!("{} joined the game", player.displayname));
+            }
+            GameEvent::MoveQueued { pid } => {
+                let name = self.name_for_pid(pid);
+                self.push_log(format!("{} submitted a move", name));
+            }
+            GameEvent::MoveRejected { pid, feedback } => {
+                let name = self.name_for_pid(pid);
+                self.push_log(format!("Move rejected for {}: {}", name, feedback));
+                if pid == self.pid {
+                    self.phase = SelectionPhase::SelectingSource;
+                }
+            }
+            GameEvent::ConflictsDetected { moves } => {
+                if moves.is_empty() {
+                    self.push_log("Conflict detected but no moves reported".to_string());
+                } else {
+                    let summary: Vec<String> = moves
+                        .iter()
+                        .map(|mv| {
+                            format!(
+                                "{}: {} -> {}",
+                                self.name_for_pid(mv.who),
+                                fmt_coord(mv.from),
+                                fmt_coord(mv.to)
+                            )
+                        })
+                        .collect();
+                    self.push_log(format!(
+                        "Conflicts detected:
+{}",
+                        summary.join(
+                            "
+"
+                        )
+                    ));
+                }
+                self.needs_state_refresh = true;
+                self.phase = SelectionPhase::SelectingSource;
+            }
+            GameEvent::MovesResolved {
+                results,
+                automaton,
+                winner,
+            } => {
+                for AppliedMove { mv, outcome } in results {
+                    let name = self.name_for_pid(mv.who);
+                    self.push_log(format!(
+                        "{}: {} -> {} => {}",
+                        name,
+                        fmt_coord(mv.from),
+                        fmt_coord(mv.to),
+                        outcome
+                    ));
+                }
+                if let Some(auto) = automaton {
+                    self.push_log(format!(
+                        "Automaton moved from {} to {}",
+                        fmt_coord(auto.from),
+                        fmt_coord(auto.to)
+                    ));
+                }
+                if let Some(winner) = winner {
+                    let name = self.name_for_pid(winner);
+                    self.push_log(format!("{} wins the game!", name));
+                    self.should_quit = true;
+                }
+                self.needs_state_refresh = true;
+                self.phase = SelectionPhase::SelectingSource;
+            }
+            GameEvent::RoundState { round, locked } => {
+                self.current_round = round;
+                self.locked_players = locked;
+                self.push_log(format!("Round state: {:?}", round));
+            }
+        }
+    }
+
+    async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            if let KeyCode::Char('c') = key.code {
+                self.should_quit = true;
+                return Ok(());
+            }
+        }
+        match key.code {
+            KeyCode::Char('q') => {
+                self.should_quit = true;
+            }
+            KeyCode::Char('r') => {
+                self.needs_state_refresh = true;
+            }
+            KeyCode::Esc => {
+                self.phase = SelectionPhase::SelectingSource;
+            }
+            KeyCode::Left => {
+                self.cursor.x = self.cursor.x.saturating_sub(1);
+            }
+            KeyCode::Right => {
+                if let Some(game) = &self.game {
+                    let max = game.board.size.x.saturating_sub(1);
+                    if self.cursor.x < max {
+                        self.cursor.x += 1;
+                    }
+                }
+            }
+            KeyCode::Up => {
+                if let Some(game) = &self.game {
+                    let max = game.board.size.y.saturating_sub(1);
+                    if self.cursor.y < max {
+                        self.cursor.y += 1;
+                    }
+                }
+            }
+            KeyCode::Down => {
+                self.cursor.y = self.cursor.y.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                if self.game.is_none() {
+                    return Ok(());
+                }
+                match self.phase {
+                    SelectionPhase::SelectingSource => {
+                        self.phase = SelectionPhase::SelectingDestination { from: self.cursor };
+                        self.push_log(format!("Selected {}", fmt_coord(self.cursor)));
+                    }
+                    SelectionPhase::SelectingDestination { from } => {
+                        let to = self.cursor;
+                        self.phase = SelectionPhase::SelectingSource;
+                        self.send_move(from, to).await?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    async fn send_move(&mut self, from: Coord, to: Coord) -> Result<()> {
+        let result = self
+            .client
+            .perform_move(self.game_id, self.player_uuid, from, to)
+            .await;
+        match result {
+            Ok(outcome) => {
+                self.push_log(format!(
+                    "Your move {} -> {} => {}",
+                    fmt_coord(from),
+                    fmt_coord(to),
+                    outcome.feedback
+                ));
+                if outcome.enqueued {
+                    self.push_log("All moves submitted. Resolving...".to_string());
+                }
+            }
+            Err(err) => {
+                self.push_log(format!("Move submission failed: {err:?}"));
+            }
+        }
+        Ok(())
+    }
+
+    fn board_lines(&self) -> Vec<Line<'static>> {
+        let Some(game) = &self.game else {
+            return vec![Line::from("Waiting for game state...")];
+        };
+        let mut lines = Vec::new();
+        for y in (0..game.board.size.y).rev() {
+            let mut spans = Vec::new();
+            for x in 0..game.board.size.x {
+                let coord = Coord { x, y };
+                let cell = game.board.particles[(x as usize, y as usize)];
+                let mut style = Style::default();
+                if let Some((_, owner)) = game.goals.iter().find(|(c, _)| *c == coord) {
+                    style = style.bg(player_color(*owner));
+                }
+                if cell.conflict {
+                    style = style.fg(Color::Red).add_modifier(Modifier::BOLD);
+                } else if cell.passable {
+                    style = style.fg(Color::Yellow);
+                }
+                if let Some(selected) = self.selected_coord() {
+                    if selected == coord {
+                        style = style.add_modifier(Modifier::UNDERLINED);
+                    }
+                }
+                if self.cursor == coord {
+                    style = style.add_modifier(Modifier::REVERSED);
+                }
+                let ch = match cell.what {
+                    Particle::Vacuum => '.',
+                    Particle::Repulsor => 'R',
+                    Particle::Attractor => 'A',
+                    Particle::Automaton => '@',
+                };
+                spans.push(Span::styled(format!(" {} ", ch), style));
+            }
+            lines.push(Line::from(spans));
+        }
+        lines
+    }
+
+    fn locked_label(&self) -> String {
+        if self.locked_players.is_empty() {
+            "None".to_string()
+        } else {
+            let mut names: Vec<String> = self
+                .locked_players
+                .iter()
+                .map(|pid| self.name_for_pid(*pid))
+                .collect();
+            names.sort();
+            names.join(", ")
+        }
+    }
+}
+
+fn player_color(pid: Pid) -> Color {
+    match pid.0 % 6 {
+        0 => Color::Blue,
+        1 => Color::Green,
+        2 => Color::Magenta,
+        3 => Color::Cyan,
+        4 => Color::LightYellow,
+        _ => Color::LightBlue,
+    }
+}
+
+fn fmt_coord(coord: Coord) -> String {
+    format!("({}, {})", coord.x, coord.y)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let client = BackendClient::new(cli.server.clone())?;
+
+    let player_uuid = match (cli.player, cli.player_name.as_deref()) {
+        (Some(uuid), _) => uuid,
+        (None, Some(name)) => {
+            let password = cli.player_password.as_deref().unwrap_or("");
+            client
+                .register_player(name, password)
+                .await
+                .context("failed to register player")?
+        }
+        (None, None) => {
+            return Err(anyhow!(
+                "Provide either --player UUID or --player-name to register a new player"
+            ));
+        }
+    };
+
+    let game_uuid = match (cli.game, cli.create_game) {
+        (Some(uuid), _) => uuid,
+        (None, true) => client
+            .create_game()
+            .await
+            .context("failed to create game")?,
+        (None, false) => {
+            return Err(anyhow!(
+                "Provide --game UUID to join or --create-game to make a new one"
+            ));
+        }
+    };
+
+    let pid = client
+        .join_game(game_uuid, player_uuid)
+        .await
+        .context("failed to join game")?;
+
+    let mut app = App::new(client, game_uuid, player_uuid, pid);
+    app.push_log(format!("Joined game {game_uuid} as player {}", pid.0));
+    app.refresh_state().await?;
+    if let Err(err) = app.poll().await {
+        app.push_log(format!("Initial event poll failed: {err:?}"));
+    }
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.hide_cursor()?;
+
+    let mut reader = EventStream::new();
+    let mut ticker = interval(Duration::from_millis(cli.poll_ms));
+
+    loop {
+        terminal.draw(|frame| draw_ui(frame, &app))?;
+
+        tokio::select! {
+            maybe_event = reader.next() => {
+                match maybe_event {
+                    Some(Ok(CrosstermEvent::Key(key))) => {
+                        if let Err(err) = app.handle_key(key).await {
+                            app.push_log(format!("Input error: {err:?}"));
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        app.push_log(format!("Input stream error: {err:?}"));
+                    }
+                    None => {
+                        app.push_log("Input stream closed".to_string());
+                        app.should_quit = true;
+                    }
+                }
+            }
+            _ = ticker.tick() => {
+                if let Err(err) = app.poll().await {
+                    app.push_log(format!("Polling failed: {err:?}"));
+                }
+            }
+        }
+
+        if app.should_quit {
+            break;
+        }
+    }
+
+    disable_raw_mode()?;
+    terminal.show_cursor()?;
+    {
+        let backend = terminal.backend_mut();
+        execute!(backend, LeaveAlternateScreen)?;
+        backend.flush()?;
+    }
+    Ok(())
+}
+
+fn draw_ui(frame: &mut Frame<'_>, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+        .split(frame.size());
+
+    let board_block = Block::default().title("Board").borders(Borders::ALL);
+    let board_area = board_block.inner(chunks[0]);
+    frame.render_widget(board_block, chunks[0]);
+    let board = Paragraph::new(app.board_lines()).wrap(Wrap { trim: false });
+    frame.render_widget(board, board_area);
+
+    let mut sidebar_lines = Vec::new();
+    sidebar_lines.push(Line::from(format!("You are: {}", app.player_label())));
+    sidebar_lines.push(Line::from(format!("Cursor: {}", fmt_coord(app.cursor))));
+    sidebar_lines.push(Line::from(format!(
+        "Selection: {}",
+        app.selected_coord()
+            .map(fmt_coord)
+            .unwrap_or_else(|| "(none)".to_string())
+    )));
+    sidebar_lines.push(Line::from(format!("Phase: {}", app.phase.label())));
+    sidebar_lines.push(Line::from(format!("Round: {:?}", app.current_round)));
+    sidebar_lines.push(Line::from(format!(
+        "Locked players: {}",
+        app.locked_label()
+    )));
+    sidebar_lines.push(Line::from(
+        "Controls: arrows move, Enter select, Esc cancel, r refresh, q quit",
+    ));
+    sidebar_lines.push(Line::from(""));
+
+    let mut recent: Vec<String> = app.log.iter().rev().take(20).cloned().collect();
+    recent.reverse();
+    for entry in recent {
+        sidebar_lines.push(Line::from(entry));
+    }
+
+    let sidebar = Paragraph::new(sidebar_lines)
+        .block(Block::default().title("Status").borders(Borders::ALL))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(sidebar, chunks[1]);
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,8 @@
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
-use automatafl_logic::{AutomatonDecision, Board, Coord, Move, MoveFeedback, Pid};
+use automatafl_logic::{
+    Board, Coord, Game, Move, MoveFeedback, MoveResult as LogicMoveResult, Pid, RoundState,
+};
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -8,24 +10,74 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
-
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use uuid::Uuid;
-
 use tracing_subscriber::prelude::*;
+use uuid::Uuid;
 
 #[derive(Clone)]
 struct PlayerInfo {
-    id: Uuid,
+    _id: Uuid,
     displayname: String,
-    password: String,
+    _password: String,
 }
 
 #[derive(Clone)]
 struct GameState {
-    core: automatafl_logic::Game,
-    player_ids: HashMap<Uuid, automatafl_logic::Pid>,
+    core: Game,
+    player_ids: HashMap<Uuid, Pid>,
+    next_pid: u8,
+    event_log: Vec<EventRecord>,
+    next_event_seq: u64,
+}
+
+impl GameState {
+    fn new(player_count: u8, use_column_rule: bool) -> Self {
+        let core = Game::new(Board::stock_two_player(), player_count, use_column_rule);
+        Self {
+            core,
+            player_ids: HashMap::new(),
+            next_pid: 0,
+            event_log: Vec::new(),
+            next_event_seq: 0,
+        }
+    }
+
+    fn record_event(&mut self, audience: Audience, event: GameEvent) {
+        let seq = self.next_event_seq;
+        self.next_event_seq += 1;
+        self.event_log.push(EventRecord {
+            seq,
+            audience,
+            event,
+        });
+    }
+
+    fn events_for(&self, pid: Option<Pid>, since: u64) -> Vec<EventEnvelope> {
+        self.event_log
+            .iter()
+            .filter(|evt| evt.seq >= since && evt.audience.matches(pid))
+            .map(|evt| EventEnvelope {
+                seq: evt.seq,
+                event: evt.event.clone(),
+            })
+            .collect()
+    }
+
+    fn player_summaries(&self, players: &HashMap<Uuid, PlayerInfo>) -> Vec<PlayerSummary> {
+        let mut out = Vec::new();
+        for (uuid, pid) in &self.player_ids {
+            if let Some(info) = players.get(uuid) {
+                out.push(PlayerSummary {
+                    uuid: *uuid,
+                    pid: *pid,
+                    displayname: info.displayname.clone(),
+                });
+            }
+        }
+        out.sort_by_key(|p| p.pid.0);
+        out
+    }
 }
 
 #[derive(Clone)]
@@ -36,6 +88,7 @@ struct AppState {
 
 type ServerState = State<Arc<RwLock<AppState>>>;
 
+#[derive(Debug)]
 enum AppError {
     NoSuchGame(Uuid),
     NoSuchPlayer(Uuid),
@@ -45,7 +98,6 @@ enum AppError {
 
 impl IntoResponse for AppError {
     fn into_response(self) -> axum::response::Response {
-        // i don't like this:
         match self {
             AppError::NoSuchGame(uuid) => Response::builder()
                 .status(StatusCode::NOT_FOUND)
@@ -67,21 +119,161 @@ impl IntoResponse for AppError {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum GameEvent {
+    PlayerJoined {
+        player: PlayerSummary,
+    },
+    MoveQueued {
+        pid: Pid,
+    },
+    MoveRejected {
+        pid: Pid,
+        feedback: MoveFeedback,
+    },
+    ConflictsDetected {
+        moves: Vec<Move>,
+    },
+    MovesResolved {
+        results: Vec<AppliedMove>,
+        automaton: Option<AutomatonMotion>,
+        winner: Option<Pid>,
+    },
+    RoundState {
+        round: RoundState,
+        locked: Vec<Pid>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AppliedMove {
+    mv: Move,
+    outcome: LogicMoveResult,
+}
+
+impl Clone for AppliedMove {
+    fn clone(&self) -> Self {
+        let outcome = match &self.outcome {
+            LogicMoveResult::NoSource => LogicMoveResult::NoSource,
+            LogicMoveResult::OccupiedAt(coord) => LogicMoveResult::OccupiedAt(*coord),
+            LogicMoveResult::Applied => LogicMoveResult::Applied,
+        };
+        Self {
+            mv: self.mv,
+            outcome,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AutomatonMotion {
+    from: Coord,
+    to: Coord,
+}
+
+#[derive(Clone, Copy)]
+enum Audience {
+    Broadcast,
+    Player(Pid),
+}
+
+impl Audience {
+    fn matches(&self, pid: Option<Pid>) -> bool {
+        match (self, pid) {
+            (Audience::Broadcast, _) => true,
+            (Audience::Player(expected), Some(actual)) => expected == &actual,
+            (Audience::Player(_), None) => false,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct EventRecord {
+    seq: u64,
+    audience: Audience,
+    event: GameEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EventEnvelope {
+    seq: u64,
+    event: GameEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EventsResponse {
+    events: Vec<EventEnvelope>,
+    next_seq: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PlayerSummary {
+    uuid: Uuid,
+    pid: Pid,
+    displayname: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct GameSnapshot {
+    id: Uuid,
+    game: Game,
+    players: Vec<PlayerSummary>,
+}
+
+fn default_goals(board: &Board, pid: Pid, total_players: u8) -> Vec<Coord> {
+    let max_x = board.size.x - 1;
+    let max_y = board.size.y - 1;
+    match total_players {
+        2 => match pid.0 {
+            0 => vec![Coord { x: 0, y: 0 }, Coord { x: max_x, y: 0 }],
+            1 => vec![Coord { x: max_x, y: max_y }, Coord { x: 0, y: max_y }],
+            _ => Vec::new(),
+        },
+        4 => match pid.0 {
+            0 => vec![Coord { x: 0, y: 0 }],
+            1 => vec![Coord { x: max_x, y: 0 }],
+            2 => vec![Coord { x: max_x, y: max_y }],
+            3 => vec![Coord { x: 0, y: max_y }],
+            _ => Vec::new(),
+        },
+        _ => Vec::new(),
+    }
+}
+
 async fn list_games(State(state): ServerState) -> Json<Vec<Uuid>> {
     let state = state.read().await;
-    axum::Json(state.games.keys().cloned().collect())
+    Json(state.games.keys().cloned().collect())
+}
+
+async fn game_snapshot(
+    State(state): ServerState,
+    Path(game_uuid): Path<Uuid>,
+) -> Result<Json<GameSnapshot>, AppError> {
+    let state = state.read().await;
+    let gm = state
+        .games
+        .get(&game_uuid)
+        .ok_or_else(|| AppError::NoSuchGame(game_uuid))?;
+    Ok(Json(GameSnapshot {
+        id: game_uuid,
+        game: gm.core.clone(),
+        players: gm.player_summaries(&state.players),
+    }))
 }
 
 async fn create_game(State(state): ServerState) -> Json<Uuid> {
     let mut state = state.write().await;
-    let new_game = GameState {
-        core: automatafl_logic::Game::new(Board::stock_two_player(), 2, true),
-        player_ids: HashMap::new(),
-    };
+    let mut new_game = GameState::new(2, true);
+    new_game.record_event(
+        Audience::Broadcast,
+        GameEvent::RoundState {
+            round: new_game.core.round,
+            locked: Vec::new(),
+        },
+    );
     let new_uuid = Uuid::new_v4();
-
-    state.games.insert(new_uuid.clone(), new_game);
-
+    state.games.insert(new_uuid, new_game);
     Json(new_uuid)
 }
 
@@ -91,34 +283,49 @@ async fn join_game(
     Query(player_uuid): Query<Uuid>,
 ) -> Result<Json<Pid>, AppError> {
     let mut state = state.write().await;
-    let &mut AppState {
-        ref mut players,
-        ref mut games,
-        ..
-    } = &mut *state;
-
-    let game_uuid: &Uuid = &game_uuid;
-    let player_uuid: &Uuid = &player_uuid;
+    let (players, games) = {
+        let AppState { players, games } = &mut *state;
+        (players, games)
+    };
 
     let gm = games
         .get_mut(&game_uuid)
-        .ok_or_else(|| AppError::NoSuchGame(game_uuid.clone()))?;
+        .ok_or_else(|| AppError::NoSuchGame(game_uuid))?;
+    let info = players
+        .get(&player_uuid)
+        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid))?;
 
-    let _pl = players
-        .get_mut(&player_uuid)
-        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid.clone()))?;
-
-    if gm.player_ids.len() >= (gm.core.player_count as usize) {
-        return Err(AppError::GameFull(game_uuid.clone()));
-    }
     if gm.player_ids.contains_key(&player_uuid) {
-        return Err(AppError::PlayerAlreadyExists(player_uuid.clone()));
+        return Err(AppError::PlayerAlreadyExists(player_uuid));
     }
 
-    let new_player_id = gm.player_ids.values().cloned().max().unwrap_or(Pid(0));
-    gm.player_ids.insert(*player_uuid, new_player_id);
+    if gm.player_ids.len() >= gm.core.player_count as usize {
+        return Err(AppError::GameFull(game_uuid));
+    }
 
-    Ok(Json(new_player_id))
+    let pid = Pid(gm.next_pid);
+    gm.next_pid += 1;
+
+    gm.player_ids.insert(player_uuid, pid);
+
+    // Assign default goals for the player.
+    gm.core.goals.retain(|(_, owner)| owner != &pid);
+    for goal in default_goals(&gm.core.board, pid, gm.core.player_count) {
+        gm.core.goals.push((goal, pid));
+    }
+
+    gm.record_event(
+        Audience::Broadcast,
+        GameEvent::PlayerJoined {
+            player: PlayerSummary {
+                uuid: player_uuid,
+                pid,
+                displayname: info.displayname.clone(),
+            },
+        },
+    );
+
+    Ok(Json(pid))
 }
 
 #[derive(Deserialize)]
@@ -126,40 +333,37 @@ struct RegisterPlayer {
     displayname: String,
     password: String,
 }
+
 async fn register_player(
     State(state): ServerState,
     Json(payload): Json<RegisterPlayer>,
-) -> Result<Json<Uuid>, AppError> {
+) -> Json<Uuid> {
     let new_uuid = Uuid::new_v4();
-    // scan for duplicated displayname
     state.write().await.players.insert(
-        new_uuid.clone(),
+        new_uuid,
         PlayerInfo {
-            id: new_uuid,
+            _id: new_uuid,
             displayname: payload.displayname,
-            password: payload.password,
+            _password: payload.password,
         },
     );
-
-    Ok(Json(new_uuid))
+    Json(new_uuid)
 }
 
 async fn pending_move(
     State(state): ServerState,
-    Path((game_uuid,)): Path<(Uuid,)>,
+    Path(game_uuid): Path<Uuid>,
     Query(player_uuid): Query<Uuid>,
-) -> Result<Json<Option<automatafl_logic::Move>>, AppError> {
+) -> Result<Json<Option<Move>>, AppError> {
     let state = state.read().await;
-
     let gm = state
         .games
         .get(&game_uuid)
-        .ok_or_else(|| AppError::NoSuchGame(game_uuid.clone()))?;
+        .ok_or_else(|| AppError::NoSuchGame(game_uuid))?;
     let pid = gm
         .player_ids
         .get(&player_uuid)
-        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid.clone()))?;
-
+        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid))?;
     Ok(Json(
         gm.core
             .pending_moves
@@ -176,36 +380,157 @@ struct PerformMove {
 }
 
 #[derive(Serialize, Deserialize)]
-struct MoveResult {
+struct MoveAttemptResult {
     feedback: MoveFeedback,
     enqueued: bool,
 }
+
 async fn perform_move(
     State(state): ServerState,
-    Path((game_uuid,)): Path<(Uuid,)>,
+    Path(game_uuid): Path<Uuid>,
     Query(player_uuid): Query<Uuid>,
     Json(move_to_make): Json<PerformMove>,
-) -> Result<Json<MoveResult>, AppError> {
+) -> Result<Json<MoveAttemptResult>, AppError> {
     let mut state = state.write().await;
 
     let gm = state
         .games
         .get_mut(&game_uuid)
-        .ok_or_else(|| AppError::NoSuchGame(game_uuid.clone()))?;
+        .ok_or_else(|| AppError::NoSuchGame(game_uuid))?;
 
     let pid = gm
         .player_ids
         .get(&player_uuid)
-        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid.clone()))?;
+        .ok_or_else(|| AppError::NoSuchPlayer(player_uuid))?;
 
-    let m = Move {
+    let mv = Move {
         who: *pid,
         from: move_to_make.from,
         to: move_to_make.to,
     };
-    let (feedback, enqueued) = gm.core.propose_move(m);
 
-    Ok(Json(MoveResult { feedback, enqueued }))
+    let (feedback, enqueued) = gm.core.propose_move(mv.clone());
+
+    match feedback.clone() {
+        MoveFeedback::Committed => {
+            gm.record_event(Audience::Broadcast, GameEvent::MoveQueued { pid: *pid })
+        }
+        _ => gm.record_event(
+            Audience::Player(*pid),
+            GameEvent::MoveRejected {
+                pid: *pid,
+                feedback: feedback.clone(),
+            },
+        ),
+    }
+
+    if enqueued {
+        advance_round(gm);
+    }
+
+    Ok(Json(MoveAttemptResult { feedback, enqueued }))
+}
+
+fn advance_round(game: &mut GameState) {
+    let automaton_start = game.core.board.automaton_location;
+    let pending_before: Vec<Move> = game.core.pending_moves.iter().cloned().collect();
+
+    match game.core.try_complete_round() {
+        Ok(results) => {
+            let applied: Vec<AppliedMove> = results
+                .into_iter()
+                .map(|(mv, outcome)| AppliedMove { mv, outcome })
+                .collect();
+            let automaton_end = game.core.board.automaton_location;
+            let automaton = if automaton_end != automaton_start {
+                Some(AutomatonMotion {
+                    from: automaton_start,
+                    to: automaton_end,
+                })
+            } else {
+                None
+            };
+
+            game.core.locked_players.clear();
+
+            game.record_event(
+                Audience::Broadcast,
+                GameEvent::MovesResolved {
+                    results: applied,
+                    automaton,
+                    winner: game.core.winner,
+                },
+            );
+
+            game.record_event(
+                Audience::Broadcast,
+                GameEvent::RoundState {
+                    round: game.core.round,
+                    locked: game.core.locked_players.iter().copied().collect(),
+                },
+            );
+        }
+        Err(()) => {
+            let pending_after: Vec<Move> = game.core.pending_moves.iter().cloned().collect();
+            let mut locked: Vec<Pid> = pending_after.iter().map(|mv| mv.who).collect();
+            locked.sort_by_key(|pid| pid.0);
+            locked.dedup();
+            game.core.locked_players.clear();
+            game.core.locked_players.extend(locked.iter().copied());
+
+            let mut conflicts = Vec::new();
+            for mv in pending_before {
+                if !pending_after.contains(&mv) {
+                    conflicts.push(mv);
+                }
+            }
+
+            game.record_event(
+                Audience::Broadcast,
+                GameEvent::ConflictsDetected { moves: conflicts },
+            );
+            game.record_event(
+                Audience::Broadcast,
+                GameEvent::RoundState {
+                    round: game.core.round,
+                    locked,
+                },
+            );
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct EventsQuery {
+    #[serde(default)]
+    since: Option<u64>,
+    player_uuid: Option<Uuid>,
+}
+
+async fn poll_events(
+    State(state): ServerState,
+    Path(game_uuid): Path<Uuid>,
+    Query(query): Query<EventsQuery>,
+) -> Result<Json<EventsResponse>, AppError> {
+    let state = state.read().await;
+    let gm = state
+        .games
+        .get(&game_uuid)
+        .ok_or_else(|| AppError::NoSuchGame(game_uuid))?;
+
+    let pid = match query.player_uuid {
+        Some(uuid) => Some(
+            *gm.player_ids
+                .get(&uuid)
+                .ok_or_else(|| AppError::NoSuchPlayer(uuid))?,
+        ),
+        None => None,
+    };
+
+    let since = query.since.unwrap_or(0);
+    let events = gm.events_for(pid, since);
+    let next_seq = events.last().map(|ev| ev.seq + 1).unwrap_or_else(|| since);
+    Ok(Json(EventsResponse { events, next_seq }))
 }
 
 #[tokio::main]
@@ -214,12 +539,14 @@ async fn main() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    // functionality: create, join, play, end games.
-
     let app = Router::new()
         .route("/api/v1/games", get(list_games).post(create_game))
-        .route("/api/v1/games/{id}/move", get(pending_move).post(perform_move))
-        .route("/api/v1/games/{id}", post(join_game))
+        .route("/api/v1/games/{id}", post(join_game).get(game_snapshot))
+        .route(
+            "/api/v1/games/{id}/move",
+            get(pending_move).post(perform_move),
+        )
+        .route("/api/v1/games/{id}/events", get(poll_events))
         .route("/api/v1/register", post(register_player))
         .with_state(Arc::new(RwLock::new(AppState {
             games: HashMap::new(),


### PR DESCRIPTION
## Summary
- extend the backend with round progression, event logging and snapshots
- add a polling API for per-player events alongside default goal assignment
- introduce the `automatatui` crate providing a ratatui-based terminal client

## Testing
- `cargo build -p automatatui`
- `cargo build -p automatafl-backend`
- `cargo clippy` *(fails: existing webapp crate errors referencing missing automatafl_api types)*

------
https://chatgpt.com/codex/tasks/task_e_68d4c085d98883208642b3ac7102cd45